### PR TITLE
fix: support Beeper AppImage marker layout

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,10 +7,22 @@ let
     hash = "sha256-luMwF1yCc3ja0AFVNkWU9QMdSEiyH7u25MaVT/+3BQQ=";
   };
 
-  appimageContents = pkgs.appimageTools.extract { inherit pname version src; };
+  # Beeper's current AppImage stores its AI2 marker at offset 1024,
+  # while nixpkgs' appimage-exec reads it from the ELF header.
+  patchedSrc = pkgs.runCommand "${pname}-${version}-appimage-patched" { } ''
+    cp ${src} $out
+    chmod u+w $out
+    printf '\x41\x49\x02' | dd of=$out bs=1 seek=8 conv=notrunc
+  '';
+
+  appimageContents = pkgs.appimageTools.extract {
+    inherit pname version;
+    src = patchedSrc;
+  };
 in
-appimageTools.wrapType2 rec {
-  inherit pname version src;
+appimageTools.wrapAppImage rec {
+  inherit pname version;
+  src = appimageContents;
   pkgs = pkgs;
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Summary
- support Beeper AppImages whose `AI\x02` marker is stored at offset 1024
- normalize the marker into the ELF header before nixpkgs extraction
- use the extracted AppImage directory with `wrapAppImage`

## Verification
- `nix build --no-link --print-build-logs --print-out-paths .#packages.x86_64-linux.default`
- build succeeds for Beeper 4.2.972

Note: the existing `nix flake check` output has a pre-existing failure because `packages.x86_64-linux.beeper` is an attribute set rather than a derivation.