### PR TITLE
fix: remove recursive pkgs argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,8 +23,6 @@ in
 appimageTools.wrapAppImage rec {
   inherit pname version;
   src = appimageContents;
-  pkgs = pkgs;
-
   nativeBuildInputs = [
     copyDesktopItems
   ];


### PR DESCRIPTION
The current package uses `appimageTools.wrapAppImage`, but still passes `pkgs = pkgs;`. With newer nixpkgs this causes infinite recursion during evaluation.

This removes the obsolete recursive argument. Verified by evaluating the package against the current NixOS nixpkgs: the pre-patch expression fails with infinite recursion, while this change evaluates successfully.